### PR TITLE
Support for timezone offset when server is in a different tz

### DIFF
--- a/app/party-manager.js
+++ b/app/party-manager.js
@@ -14,12 +14,12 @@ process.nextTick(() => {
 
 class PartyManager {
   constructor() {
-    let lastIntervalTime = moment().valueOf(),
-      lastIntervalDay = moment().dayOfYear();
+    let lastIntervalTime = moment().add(settings.tzOffset, 'hours').valueOf(),
+      lastIntervalDay = moment().add(settings.tzOffset, 'hours').dayOfYear();
 
     // loop to clean up raids periodically
     this.update = setInterval(() => {
-      const nowMoment = moment(),
+      const nowMoment = moment().add(settings.tzOffset, 'hours'),
         nowDay = nowMoment.dayOfYear(),
         now = nowMoment.valueOf(),
         startClearTime = now + (settings.startClearTime * 60 * 1000),

--- a/app/party.js
+++ b/app/party.js
@@ -155,7 +155,7 @@ class Party {
     }
 
     if (this.messagesSinceDeletionScheduled % 5 === 1) {
-      const timeUntilDeletion = moment(this.deletionTime).fromNow();
+      const timeUntilDeletion = moment(this.deletionTime).add(settings.tzOffset, 'hours').fromNow();
 
       PartyManager.getChannel(this.channelId)
         .then(channelResult => {

--- a/app/pokemon.js
+++ b/app/pokemon.js
@@ -267,7 +267,7 @@ class Pokemon extends Search {
         break;
 
       case 5:
-        stamina = 18750;
+        stamina = 12500;
         break;
     }
 

--- a/app/process-image.js
+++ b/app/process-image.js
@@ -535,7 +535,7 @@ class ImageProcessing {
           phoneTime = moment(phoneTime, ['hmm a', 'h:m a']);
         } else {
           // figure out if time should be AM or PM
-          const now = moment(),
+          const now = moment().add(settings.tzOffset, 'hours'),
             timeAM = moment(phoneTime + ' am', ['hmm a', 'Hmm', 'h:m a', 'H:m']),
             timePM = moment(phoneTime + ' pm', ['hmm a', 'Hmm', 'h:m a', 'H:m']),
             times = [timeAM.diff(now), timePM.diff(now)];

--- a/app/raid.js
+++ b/app/raid.js
@@ -36,7 +36,7 @@ class Raid extends Party {
       raid.createdById = memberId;
       raid.isExclusive = !!pokemon.exclusive;
       raid.sourceChannelId = sourceChannelId;
-      raid.creationTime = moment().valueOf();
+      raid.creationTime = moment().add(settings.tzOffset, 'hours').valueOf();
       raid.lastPossibleTime = raid.creationTime + (raid.isExclusive ?
         (settings.exclusiveRaidIncubateDuration + settings.exclusiveRaidHatchedDuration) * 60 * 1000 :
         (settings.standardRaidIncubateDuration + settings.standardRaidHatchedDuration) * 60 * 1000);
@@ -606,7 +606,7 @@ class Raid extends Party {
         `EX Raid against ${pokemon}` :
         `Level ${this.pokemon.tier} Raid against ${pokemon}`,
 
-      now = moment(),
+      now = moment().add(settings.tzOffset, 'hours'),
 
       calendarFormat = {
         sameDay: 'LT',

--- a/app/train.js
+++ b/app/train.js
@@ -29,7 +29,7 @@ class RaidTrain extends Party {
     // add some extra train data to remember
     train.createdById = memberId;
     train.sourceChannelId = sourceChannelId;
-    train.creationTime = moment().valueOf();
+    train.creationTime = moment().add(settings.tzOffset, 'hours').valueOf();
 
     train.trainName = trainName;
     train.gymId = undefined;

--- a/data/pokemon.json
+++ b/data/pokemon.json
@@ -1794,7 +1794,8 @@
     "name": "regigigas"
   },
   {
-    "name": "giratina"
+    "name": "giratina",
+    "tier":  5
   },
   {
     "name": "cresselia"

--- a/data/pokemon.json
+++ b/data/pokemon.json
@@ -773,7 +773,8 @@
     "name": "togepi"
   },
   {
-    "name": "togetic"
+    "name": "togetic",
+    "tier": 4
   },
   {
     "name": "natu"

--- a/data/pokemon.json
+++ b/data/pokemon.json
@@ -1794,7 +1794,13 @@
     "name": "regigigas"
   },
   {
-    "name": "giratina",
+    "name": "giratina_altered",
+    "overrideName": "Giratina - Altered",
+    "tier":  5
+  },
+  {
+    "name": "giratina_origin",
+    "overrideName": "Giratina - Origin",
     "tier":  5
   },
   {

--- a/data/pokemon.json
+++ b/data/pokemon.json
@@ -1796,7 +1796,10 @@
   },
   {
     "name": "giratina_altered",
-    "overrideName": "Giratina - Altered",
+    "overrideName": "Giratina",
+    "nickname": [
+      "altered"
+    ],
     "tier":  5
   },
   {

--- a/data/settings.json
+++ b/data/settings.json
@@ -25,7 +25,7 @@
     "bot-lab": "the-bot-lab",
     "mod-bot-lab": "mod-bot-only",
     "unown": "unown-sightings",
-    "ex-gym-raids": "potential-ex-gym-raids"
+    "ex-gym-raids": "ex-gym-raids"
   },
   "helpGroups": [
     "basic-raid",

--- a/data/settings.json
+++ b/data/settings.json
@@ -33,5 +33,6 @@
     "roles",
     "notifications",
     "util"
-  ]
+  ],
+  "tzOffset":-2
 }

--- a/types/time.js
+++ b/types/time.js
@@ -17,7 +17,7 @@ class TimeType extends Commando.ArgumentType {
   validate(value, message, arg) {
     const isExRaid = this.isExclusiveRaid(value, message, arg),
       partyExists = PartyManager.validParty(message.channel.id),
-      now = moment(),
+      now = moment().add(settings.tzOffset, 'hours'),
       partyCreationTime = partyExists ?
         moment(PartyManager.getParty(message.channel.id).creationTime) :
         now,
@@ -163,7 +163,7 @@ class TimeType extends Commando.ArgumentType {
   parse(value, message, arg) {
     const isExRaid = this.isExclusiveRaid(value, message, arg),
       partyExists = PartyManager.validParty(message.channel.id),
-      now = moment(),
+      now = moment().add(settings.tzOffset, 'hours'),
       partyCreationTime = partyExists ?
         moment(PartyManager.getParty(message.channel.id).creationTime) :
         now,


### PR DESCRIPTION
This is a quick fix by simply using a new setting named tzOffset in order to adjust the moment() time values when the server is in a different tz than the players. Note this only accounts for whole hour offsets and does not implement a full timezone difference in order to offset by factional values.